### PR TITLE
refactor: async trait for shorthand interactions

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -21,15 +21,8 @@ use crate::regex::{randomly_generate, Alphabet, Difficulty, RegexAst};
 use anyhow::anyhow;
 use indexmap::{indexmap, indexset, IndexMap, IndexSet};
 use serenity::{
-    builder::{CreateEmbed, CreateInteractionResponse, EditInteractionResponse},
-    http::Http,
-    model::{
-        id::{ChannelId, UserId},
-        interactions::{
-            application_command::ApplicationCommandInteraction,
-            message_component::MessageComponentInteraction,
-        },
-    },
+    builder::CreateEmbed,
+    model::id::{ChannelId, UserId},
     utils::Colour,
 };
 use std::{
@@ -56,52 +49,7 @@ impl<T> Tsx<T> {
     }
 }
 
-pub enum Interactions {
-    Command(ApplicationCommandInteraction),
-    #[allow(dead_code)]
-    Component(Box<MessageComponentInteraction>),
-}
-
-impl Interactions {
-    pub async fn create_interaction_response<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> anyhow::Result<()>
-    where
-        F: FnOnce(&mut CreateInteractionResponse) -> &mut CreateInteractionResponse,
-    {
-        match self {
-            Interactions::Command(command) => command.create_interaction_response(http, f).await?,
-            Interactions::Component(component) => {
-                (*component).create_interaction_response(http, f).await?
-            }
-        }
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub async fn edit_original_interaction_response<F>(
-        &self,
-        http: impl AsRef<Http>,
-        f: F,
-    ) -> anyhow::Result<serenity::model::channel::Message>
-    where
-        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
-    {
-        Ok(match self {
-            Interactions::Command(command) => {
-                command.edit_original_interaction_response(http, f).await?
-            }
-            Interactions::Component(component) => {
-                (*component)
-                    .edit_original_interaction_response(http, f)
-                    .await?
-            }
-        })
-    }
-}
-
+/// opaque-type of `anyhow::Result<String>` for logging
 pub enum Msg {
     Ok(String),
     Err(anyhow::Error),
@@ -111,11 +59,6 @@ pub struct Quiz {
     regex: RegexAst,
     history: IndexMap<String, String>,
     participants: IndexSet<UserId>,
-}
-
-#[allow(dead_code)]
-pub struct Container {
-    pub channel_map: IndexMap<ChannelId, Option<Quiz>>,
 }
 
 impl Quiz {
@@ -203,6 +146,10 @@ impl Default for Quiz {
     fn default() -> Self {
         Self::new()
     }
+}
+
+pub struct Container {
+    pub channel_map: IndexMap<ChannelId, Option<Quiz>>,
 }
 
 impl Container {

--- a/src/command_ext.rs
+++ b/src/command_ext.rs
@@ -1,0 +1,74 @@
+/*
+ * ISC License
+ *
+ * Copyright (c) 2021 Mitama Lab
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+use anyhow::{anyhow, Context};
+use serenity::{
+    async_trait,
+    builder::CreateEmbed,
+    http::Http,
+    model::interactions::{
+        application_command::ApplicationCommandInteraction, InteractionResponseType,
+    },
+};
+
+/// Common interface of Command and Component
+#[async_trait]
+pub trait CommandExt {
+    async fn message<T: ToString + Send + Sync>(
+        &self,
+        http: impl AsRef<Http> + Send + Sync + 'async_trait,
+        content: T,
+    ) -> anyhow::Result<()>;
+    async fn embed(
+        &self,
+        http: impl AsRef<Http> + Send + Sync + 'async_trait,
+        embed: CreateEmbed,
+    ) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+impl CommandExt for ApplicationCommandInteraction {
+    async fn message<T: ToString + Send + Sync>(
+        &self,
+        http: impl AsRef<Http> + Send + Sync + 'async_trait,
+        content: T,
+    ) -> anyhow::Result<()> {
+        self.create_interaction_response(&http, |response| {
+            response
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(|message| message.content(content))
+        })
+        .await
+        .with_context(|| anyhow!("serenity error"))
+    }
+
+    async fn embed(
+        &self,
+        http: impl AsRef<Http> + Send + Sync + 'async_trait,
+        embed: CreateEmbed,
+    ) -> anyhow::Result<()> {
+        self.create_interaction_response(&http, |response| {
+            response
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(|message| message.add_embed(embed))
+        })
+        .await
+        .with_context(|| anyhow!("serenity error"))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,10 @@
 // println!("{foo}");
 //          ~~~~~~~ format args capture (seem to be C#)
 #![feature(format_args_capture)]
+#![feature(in_band_lifetimes)]
 
 pub mod bot;
+pub mod command_ext;
 pub mod commands;
 pub mod concepts;
 pub mod notification;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use indoc::indoc;
 use once_cell::sync::Lazy;
 use regexsoup::{
     bot::{Container, Msg, Tsx},
+    command_ext::CommandExt,
     commands,
     concepts::SameAs,
     notification::{Notification, SlashCommand, To},
@@ -40,7 +41,7 @@ use serenity::{
         gateway::Ready,
         interactions::{
             application_command::{ApplicationCommand, ApplicationCommandOptionType},
-            Interaction, InteractionResponseType,
+            Interaction,
         },
     },
     utils::Colour,
@@ -181,13 +182,7 @@ impl EventHandler for Handler {
                                 .channel_map
                                 .insert(command.channel_id, Some(quiz));
                             let _ = command
-                                .create_interaction_response(&ctx.http, |response| {
-                                    response
-                                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                                        .interaction_response_data(|message| {
-                                            message.content("新しいREGガメのスープを開始します")
-                                        })
-                                })
+                                .message(&ctx.http, "新しいREGガメのスープを開始します")
                                 .await
                                 .with_context(|| anyhow!("ERROR: fail to interaction"))
                                 .logging_with(|_| "successfully started new regex-soup.")
@@ -201,13 +196,7 @@ impl EventHandler for Handler {
                                 false,
                             );
                             let _ = command
-                                .create_interaction_response(&ctx.http, |response| {
-                                    response
-                                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                                        .interaction_response_data(|message| {
-                                            message.add_embed(embed)
-                                        })
-                                })
+                                .embed(&ctx.http, embed)
                                 .await
                                 .with_context(|| anyhow!("ERROR: fail to interaction"))
                                 .logging_with(move |_| format!("ERROR: {why}"))
@@ -235,15 +224,7 @@ impl EventHandler for Handler {
 
                         if !is_joined {
                             let _ = command
-                                .create_interaction_response(&ctx.http, |response| {
-                                    response
-                                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                                        .interaction_response_data(|message| {
-                                            message.content(
-                                                "まずは`join`コマンドで参加を登録してください",
-                                            )
-                                        })
-                                })
+                                .message(&ctx.http, "まずは`join`コマンドで参加を登録してください")
                                 .await;
                             return;
                         }
@@ -277,13 +258,7 @@ impl EventHandler for Handler {
                                         },
                                     );
                                 let _ = command
-                                    .create_interaction_response(&ctx.http, |response| {
-                                        response
-                                            .kind(InteractionResponseType::ChannelMessageWithSource)
-                                            .interaction_response_data(|message| {
-                                                message.content(&msg)
-                                            })
-                                    })
+                                    .message(&ctx.http, &msg)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| "successfully finished query command.")
@@ -297,13 +272,7 @@ impl EventHandler for Handler {
                                     false,
                                 );
                                 let _ = command
-                                    .create_interaction_response(&ctx.http, |response| {
-                                        response
-                                            .kind(InteractionResponseType::ChannelMessageWithSource)
-                                            .interaction_response_data(|message| {
-                                                message.add_embed(embed)
-                                            })
-                                    })
+                                    .embed(&ctx.http, embed)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| {
@@ -334,15 +303,7 @@ impl EventHandler for Handler {
 
                         if !is_joined {
                             let _ = command
-                                .create_interaction_response(&ctx.http, |response| {
-                                    response
-                                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                                        .interaction_response_data(|message| {
-                                            message.content(
-                                                "まずは`join`コマンドで参加を登録してください",
-                                            )
-                                        })
-                                })
+                                .message(&ctx.http, "まずは`join`コマンドで参加を登録してください")
                                 .await
                                 .with_context(|| anyhow!("ERROR: fail to interaction"))
                                 .logging_with(|_| {
@@ -397,13 +358,7 @@ impl EventHandler for Handler {
                                         .and_modify(|quiz| *quiz = None);
                                 }
                                 let _ = command
-                                    .create_interaction_response(&ctx.http, |response| {
-                                        response
-                                            .kind(InteractionResponseType::ChannelMessageWithSource)
-                                            .interaction_response_data(|message| {
-                                                message.content(&msg)
-                                            })
-                                    })
+                                    .message(&ctx.http, &msg)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| "successfully finished guess command.")
@@ -417,13 +372,7 @@ impl EventHandler for Handler {
                                     false,
                                 );
                                 let _ = command
-                                    .create_interaction_response(&ctx.http, |response| {
-                                        response
-                                            .kind(InteractionResponseType::ChannelMessageWithSource)
-                                            .interaction_response_data(|message| {
-                                                message.add_embed(embed)
-                                            })
-                                    })
+                                    .embed(&ctx.http, embed)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| {
@@ -471,11 +420,7 @@ impl EventHandler for Handler {
                                 },
                             );
                         let _ = command
-                            .create_interaction_response(&ctx.http, |response| {
-                                response
-                                    .kind(InteractionResponseType::ChannelMessageWithSource)
-                                    .interaction_response_data(|message| message.add_embed(embed))
-                            })
+                            .embed(&ctx.http, embed)
                             .await
                             .with_context(|| anyhow!("ERROR: fail to interaction"))
                             .logging_with(|_| "parse error: successfully finished summary command.")
@@ -506,11 +451,7 @@ impl EventHandler for Handler {
                             );
 
                         let _ = command
-                            .create_interaction_response(&ctx.http, |response| {
-                                response
-                                    .kind(InteractionResponseType::ChannelMessageWithSource)
-                                    .interaction_response_data(|message| message.content(&msg))
-                            })
+                            .message(&ctx.http, &msg)
                             .await
                             .with_context(|| anyhow!("ERROR: fail to interaction"))
                             .logging_with(|_| "successfully finished join command.")
@@ -566,23 +507,11 @@ impl EventHandler for Handler {
                                 .channel_map
                                 .entry(command.channel_id)
                                 .and_modify(|quiz| *quiz = None);
-                            let _ = command
-                                .create_interaction_response(&ctx.http, |response| {
-                                    response
-                                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                                        .interaction_response_data(|message| {
-                                            message.content(format!("`{ans}`"))
-                                        })
-                                })
-                                .await;
+                            let _ = command.message(&ctx.http, format!("`{ans}`")).await;
                             return;
                         }
                         let _ = command
-                            .create_interaction_response(&ctx.http, |response| {
-                                response
-                                    .kind(InteractionResponseType::ChannelMessageWithSource)
-                                    .interaction_response_data(|message| message.content(&msg))
-                            })
+                            .message(&ctx.http, &msg)
                             .await
                             .with_context(|| anyhow!("ERROR: fail to interaction"))
                             .logging_with(|_| "successfully finished give-up command.")
@@ -645,11 +574,7 @@ impl EventHandler for Handler {
                             false,
                         );
                     let _ = command
-                        .create_interaction_response(&ctx.http, |response| {
-                            response
-                                .kind(InteractionResponseType::ChannelMessageWithSource)
-                                .interaction_response_data(|message| message.add_embed(embed))
-                        })
+                        .embed(&ctx.http, embed)
                         .await
                         .with_context(|| anyhow!("ERROR: fail to interaction"))
                         .logging_with(|_| "successfully finished help command.")


### PR DESCRIPTION
Aggregates copying and pasting code caused by `create_interaction_response` into a trait.