### PR TITLE
fix #20 

### DIFF
--- a/.github/workflows/catch_and_flow.yml
+++ b/.github/workflows/catch_and_flow.yml
@@ -6,7 +6,10 @@ on:
       - 'src/**'
       - 'test/**'
       - 'Cargo.lock'
-    branches: [ 'feature/*', 'master' ]
+    branches:
+      - 'feature/*'
+      - 'fix/*'
+      - 'master'
 
 jobs:
   clippy_check:

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -64,30 +64,30 @@ pub struct Quiz {
     participants: IndexSet<UserId>,
 }
 
-pub enum Inspection {
+pub enum InspectionAcceptance {
     Accepted(String),
     WrongAnswer(String),
 }
 
-impl ToString for Inspection {
+impl ToString for InspectionAcceptance {
     fn to_string(&self) -> String {
         match self {
-            Inspection::Accepted(input) => format!("{input} => AC"),
-            Inspection::WrongAnswer(input) => format!("{input} => WA"),
+            InspectionAcceptance::Accepted(input) => format!("{input} => AC"),
+            InspectionAcceptance::WrongAnswer(input) => format!("{input} => WA"),
         }
     }
 }
 
-pub enum IsMatch {
+pub enum QueryMatch {
     Yes(String),
     No(String),
 }
 
-impl ToString for IsMatch {
+impl ToString for QueryMatch {
     fn to_string(&self) -> String {
         match self {
-            IsMatch::Yes(input) => format!("{input} => Yes"),
-            IsMatch::No(input) => format!("{input} => No"),
+            QueryMatch::Yes(input) => format!("{input} => Yes"),
+            QueryMatch::No(input) => format!("{input} => No"),
         }
     }
 }
@@ -115,7 +115,7 @@ impl Quiz {
         }
     }
 
-    pub fn query(&mut self, input: &str) -> anyhow::Result<IsMatch> {
+    pub fn query(&mut self, input: &str) -> anyhow::Result<QueryMatch> {
         let alphabets = if input.eq(r#""""#) {
             vec![]
         } else {
@@ -127,21 +127,21 @@ impl Quiz {
             .entry(input.to_string())
             .or_insert((if is_match { "Yes" } else { "No" }).to_string());
         if is_match {
-            Ok(IsMatch::Yes(input.to_string()))
+            Ok(QueryMatch::Yes(input.to_string()))
         } else {
-            Ok(IsMatch::No(input.to_string()))
+            Ok(QueryMatch::No(input.to_string()))
         }
     }
 
-    pub fn inspect(&self, input: &str) -> anyhow::Result<Inspection> {
+    pub fn inspect(&self, input: &str) -> anyhow::Result<InspectionAcceptance> {
         let ast = RegexAst::parse_str(input)?;
         let alphabets = ast.used_alphabets().iter().cloned().collect_vec();
         self.validate(&alphabets)?;
         Ok(self
             .regex
             .equivalent_to(&ast)
-            .then(|| Inspection::Accepted(format!("{} => AC", &input)))
-            .unwrap_or_else(|| Inspection::WrongAnswer(format!("{} => WA", &input))))
+            .then(|| InspectionAcceptance::Accepted(format!("{} => AC", &input)))
+            .unwrap_or_else(|| InspectionAcceptance::WrongAnswer(format!("{} => WA", &input))))
     }
 
     pub fn register(&mut self, user: UserId) -> anyhow::Result<()> {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -20,6 +20,7 @@
 use crate::regex::{randomly_generate, Alphabet, Difficulty, RegexAst};
 use anyhow::anyhow;
 use indexmap::{indexmap, indexset, IndexMap, IndexSet};
+use itertools::Itertools;
 use serenity::{
     builder::CreateEmbed,
     model::id::{ChannelId, UserId},
@@ -30,6 +31,7 @@ use std::{
     num::NonZeroU8,
     sync::{Arc, Mutex},
 };
+use strum::IntoEnumIterator;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 /// Struct that holds sender and receiver
@@ -56,9 +58,38 @@ pub enum Msg {
 }
 
 pub struct Quiz {
+    size: u8,
     regex: RegexAst,
     history: IndexMap<String, String>,
     participants: IndexSet<UserId>,
+}
+
+pub enum Inspection {
+    Accepted(String),
+    WrongAnswer(String),
+}
+
+impl ToString for Inspection {
+    fn to_string(&self) -> String {
+        match self {
+            Inspection::Accepted(input) => format!("{input} => AC"),
+            Inspection::WrongAnswer(input) => format!("{input} => WA"),
+        }
+    }
+}
+
+pub enum IsMatch {
+    Yes(String),
+    No(String),
+}
+
+impl ToString for IsMatch {
+    fn to_string(&self) -> String {
+        match self {
+            IsMatch::Yes(input) => format!("{input} => Yes"),
+            IsMatch::No(input) => format!("{input} => No"),
+        }
+    }
 }
 
 impl Quiz {
@@ -66,6 +97,7 @@ impl Quiz {
         let regex = randomly_generate(&Difficulty(3u8.try_into().unwrap()));
         println!("{}", regex);
         Self {
+            size: 3u8,
             regex,
             history: indexmap! {},
             participants: indexset! {},
@@ -76,19 +108,40 @@ impl Quiz {
         let regex = randomly_generate(&Difficulty(difficulty));
         println!("{}", regex);
         Self {
+            size: difficulty.into(),
             regex,
             history: indexmap! {},
             participants: indexset! {},
         }
     }
 
-    pub fn query(&mut self, input: &[Alphabet]) -> bool {
-        let is_match = self.regex.matches(input);
-        let input_string = Alphabet::slice_to_plain_string(input);
+    pub fn query(&mut self, input: &str) -> anyhow::Result<IsMatch> {
+        let alphabets = if input.eq(r#""""#) {
+            vec![]
+        } else {
+            Alphabet::vec_from_str(input)?
+        };
+        self.validate(&alphabets)?;
+        let is_match = self.regex.matches(&alphabets);
         self.history
-            .entry(input_string)
+            .entry(input.to_string())
             .or_insert((if is_match { "Yes" } else { "No" }).to_string());
-        is_match
+        if is_match {
+            Ok(IsMatch::Yes(input.to_string()))
+        } else {
+            Ok(IsMatch::No(input.to_string()))
+        }
+    }
+
+    pub fn inspect(&self, input: &str) -> anyhow::Result<Inspection> {
+        let ast = RegexAst::parse_str(input)?;
+        let alphabets = ast.used_alphabets().iter().cloned().collect_vec();
+        self.validate(&alphabets)?;
+        Ok(self
+            .regex
+            .equivalent_to(&ast)
+            .then(|| Inspection::Accepted(format!("{} => AC", &input)))
+            .unwrap_or_else(|| Inspection::WrongAnswer(format!("{} => WA", &input))))
     }
 
     pub fn register(&mut self, user: UserId) -> anyhow::Result<()> {
@@ -96,10 +149,6 @@ impl Quiz {
             .insert(user)
             .then(|| ())
             .ok_or_else(|| anyhow!("already registered."))
-    }
-
-    pub fn guess(&self, input: &RegexAst) -> bool {
-        self.regex.equivalent_to(input)
     }
 
     pub fn accepts_give_up(&mut self, user: &UserId) -> anyhow::Result<()> {
@@ -139,6 +188,26 @@ impl Quiz {
 
     pub fn get_answer_regex(&self) -> RegexAst {
         self.regex.clone()
+    }
+
+    fn validate(&self, input: &[Alphabet]) -> anyhow::Result<()> {
+        let domain = Alphabet::iter().take(self.size.into()).collect_vec();
+        let invalid = input.iter().filter(|c| !domain.contains(c)).collect_vec();
+        invalid.is_empty().then(|| ()).ok_or_else(|| {
+            anyhow!(
+                indoc::indoc! {"
+                    Domain Error: {:?} {}.
+                    Valid Alphabets are {:?}.
+                "},
+                invalid,
+                if invalid.len() == 1 {
+                    "is not a valid Alphabet"
+                } else {
+                    "are not valid Alphabets"
+                },
+                domain
+            )
+        })
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,15 @@
 use anyhow::{anyhow, Context};
 use counted_array::counted_array;
 use indoc::indoc;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regexsoup::{
-    bot::{Container, Msg, Tsx},
+    bot::{Container, Inspection, Msg, Tsx},
     command_ext::CommandExt,
     commands,
     concepts::SameAs,
     notification::{Notification, SlashCommand, To},
-    regex::{Alphabet, RegexAst},
+    regex::Alphabet,
 };
 use serenity::{
     async_trait,
@@ -53,6 +54,7 @@ use std::{
     num::NonZeroU8,
     sync::{Arc, Mutex},
 };
+use strum::IntoEnumIterator;
 use tokio::sync::mpsc::channel;
 
 counted_array!(
@@ -181,8 +183,16 @@ impl EventHandler for Handler {
                                 .unwrap()
                                 .channel_map
                                 .insert(command.channel_id, Some(quiz));
+                            let domain =
+                                Alphabet::iter().take(difficulty.get().into()).collect_vec();
                             let _ = command
-                                .message(&ctx.http, "新しいREGガメのスープを開始します")
+                                .message(
+                                    &ctx.http,
+                                    format!(
+                                        "character set = {domain:?} \
+                                         で新しいREGガメのスープを開始します"
+                                    ),
+                                )
                                 .await
                                 .with_context(|| anyhow!("ERROR: fail to interaction"))
                                 .logging_with(|_| "successfully started new regex-soup.")
@@ -213,52 +223,47 @@ impl EventHandler for Handler {
                             .channel_map
                             .get_mut(&command.channel_id)
                             .map_or_else(
-                                || false,
+                                || None,
                                 |quiz| {
                                     quiz.as_ref().map_or_else(
-                                        || false,
-                                        |quiz| quiz.is_participant(&command.user.id),
+                                        || Some(None),
+                                        |quiz| Some(Some(quiz.is_participant(&command.user.id))),
                                     )
                                 },
                             );
 
-                        if !is_joined {
-                            let _ = command
-                                .message(&ctx.http, "まずは`join`コマンドで参加を登録してください")
-                                .await;
-                            return;
+                        match is_joined {
+                            None | Some(None) => {
+                                let _ = command.message(&ctx.http, "問題が開始していません").await;
+                                return;
+                            }
+                            Some(Some(false)) => {
+                                let _ = command
+                                    .message(
+                                        &ctx.http,
+                                        "まずは`join`コマンドで参加を登録してください",
+                                    )
+                                    .await;
+                                return;
+                            }
+                            _ => {}
                         }
 
-                        let original_input =
-                            dictionary.get("input").unwrap().to::<String>().unwrap();
-                        let input = if original_input == r#""""# {
-                            Ok(vec![])
-                        } else {
-                            Alphabet::vec_from_str(&original_input)
-                        };
-                        match input {
-                            Ok(valid_input) => {
-                                let msg = CONTAINER
-                                    .lock()
-                                    .unwrap()
-                                    .channel_map
-                                    .get_mut(&command.channel_id)
-                                    .map_or_else(
-                                        || "ゲームが開始していません".to_string(),
-                                        |quiz| {
-                                            if let Some(quiz) = quiz {
-                                                let is_match = quiz.query(&valid_input);
-                                                format!(
-                                                    "{original_input} => {}",
-                                                    if is_match { "Yes" } else { "No" }
-                                                )
-                                            } else {
-                                                "ゲームが開始していません".to_string()
-                                            }
-                                        },
-                                    );
+                        let input = dictionary.get("input").unwrap().to::<String>().unwrap();
+                        let is_match = CONTAINER
+                            .lock()
+                            .unwrap()
+                            .channel_map
+                            .get_mut(&command.channel_id)
+                            .unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .query(&input);
+
+                        match is_match {
+                            Ok(is_match) => {
                                 let _ = command
-                                    .message(&ctx.http, &msg)
+                                    .message(&ctx.http, is_match)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| "successfully finished query command.")
@@ -292,64 +297,47 @@ impl EventHandler for Handler {
                             .channel_map
                             .get_mut(&command.channel_id)
                             .map_or_else(
-                                || false,
+                                || None,
                                 |quiz| {
                                     quiz.as_ref().map_or_else(
-                                        || false,
-                                        |quiz| quiz.is_participant(&command.user.id),
+                                        || Some(None),
+                                        |quiz| Some(Some(quiz.is_participant(&command.user.id))),
                                     )
                                 },
                             );
 
-                        if !is_joined {
-                            let _ = command
-                                .message(&ctx.http, "まずは`join`コマンドで参加を登録してください")
-                                .await
-                                .with_context(|| anyhow!("ERROR: fail to interaction"))
-                                .logging_with(|_| {
-                                    "not yet joined: successfully finished to send error message."
-                                })
-                                .await;
-                            return;
+                        match is_joined {
+                            None | Some(None) => {
+                                let _ = command.message(&ctx.http, "問題が開始していません").await;
+                                return;
+                            }
+                            Some(Some(false)) => {
+                                let _ = command
+                                    .message(
+                                        &ctx.http,
+                                        "まずは`join`コマンドで参加を登録してください",
+                                    )
+                                    .await;
+                                return;
+                            }
+                            _ => {}
                         }
 
-                        let original_input =
-                            dictionary.get("regex").unwrap().to::<String>().unwrap();
-                        let input = RegexAst::parse_str(&original_input);
-                        match input {
-                            Ok(valid_input) => {
-                                let (msg, is_accepted) = CONTAINER
-                                    .lock()
-                                    .unwrap()
-                                    .channel_map
-                                    .get_mut(&command.channel_id)
-                                    .map_or_else(
-                                        || ("ゲームが開始していません".to_string(), false),
-                                        |quiz| {
-                                            if let Some(quiz) = quiz {
-                                                if quiz.guess(&valid_input) {
-                                                    (
-                                                        format!(
-                                                            indoc! {"
-                                                            - `{}` => AC
-                                                            - original answer is `{}`
-                                                            - {} queries
-                                                        "},
-                                                            original_input,
-                                                            quiz.get_answer_regex(),
-                                                            quiz.len(),
-                                                        ),
-                                                        true,
-                                                    )
-                                                } else {
-                                                    (format!("`{original_input}` => WA"), false)
-                                                }
-                                            } else {
-                                                ("ゲームが開始していません".to_string(), false)
-                                            }
-                                        },
-                                    );
-                                if is_accepted {
+                        let input = dictionary.get("regex").unwrap().to::<String>().unwrap();
+
+                        let inspection = CONTAINER
+                            .lock()
+                            .unwrap()
+                            .channel_map
+                            .get_mut(&command.channel_id)
+                            .unwrap()
+                            .as_mut()
+                            .unwrap()
+                            .inspect(&input);
+
+                        match inspection {
+                            Ok(res) => {
+                                if let Inspection::Accepted(_) = res {
                                     CONTAINER
                                         .lock()
                                         .unwrap()
@@ -358,7 +346,7 @@ impl EventHandler for Handler {
                                         .and_modify(|quiz| *quiz = None);
                                 }
                                 let _ = command
-                                    .message(&ctx.http, &msg)
+                                    .message(&ctx.http, res)
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| "successfully finished guess command.")
@@ -376,8 +364,7 @@ impl EventHandler for Handler {
                                     .await
                                     .with_context(|| anyhow!("ERROR: fail to interaction"))
                                     .logging_with(|_| {
-                                        "invalid input: successfully finished to send error \
-                                         message."
+                                        "parse error: successfully finished to send error message."
                                     })
                                     .await;
                             }
@@ -561,7 +548,7 @@ impl EventHandler for Handler {
                         .field(
                             "/join",
                             indoc! {r#"
-                                You have to `/join` first to take part in the quiz!.
+                                You have to `/join` first to take part in the quiz!
                             "#},
                             false,
                         )
@@ -569,7 +556,7 @@ impl EventHandler for Handler {
                             "/give-up",
                             indoc! {r#"
                                 When all participants have `give-up`,
-                                the quiz will end and the answers will be revealed!.
+                                the quiz will end and the answers will be revealed!
                             "#},
                             false,
                         );
@@ -693,11 +680,11 @@ pub static CENTRAL: Lazy<Tsx<Msg>> = Lazy::new(|| {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Configure the client with your Discord bot token in the environment.
-    let token = std::env::var("REGEX_SOUP_TOKEN").unwrap();
+    let token = std::env::var("REGEX_SOUP_TOKEN").expect("not fount `REGEX_SOUP_TOKEN`");
 
     // The Application Id is usually the Bot User Id.
     let application_id = std::env::var("REGEX_SOUP_ID")
-        .unwrap()
+        .expect("not fount `REGEX_SOUP_ID`")
         .parse::<u64>()
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use indoc::indoc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regexsoup::{
-    bot::{Container, Inspection, Msg, Tsx},
+    bot::{Container, InspectionAcceptance, Msg, Tsx},
     command_ext::CommandExt,
     commands,
     concepts::SameAs,
@@ -337,7 +337,7 @@ impl EventHandler for Handler {
 
                         match inspection {
                             Ok(res) => {
-                                if let Inspection::Accepted(_) = res {
+                                if let InspectionAcceptance::Accepted(_) = res {
                                     CONTAINER
                                         .lock()
                                         .unwrap()

--- a/src/regex/regex_tree.rs
+++ b/src/regex/regex_tree.rs
@@ -237,7 +237,7 @@ impl RegexAst {
     }
 
     /// Set of alphabets used within this AST.
-    fn used_alphabets(&self) -> HashSet<Alphabet> {
+    pub fn used_alphabets(&self) -> HashSet<Alphabet> {
         let mut accum = HashSet::new();
         let mut exprs_to_process = vec![self];
 


### PR DESCRIPTION
If size is 2, the domain character set is `{a, b}`.
This PR allows to validate and reject characters `c` , `d` and so on.

![image](https://user-images.githubusercontent.com/8962662/134124294-35acffdd-5a40-4034-9889-4c1147e2709b.png)
